### PR TITLE
Changed AOB::Scan to return DWORD

### DIFF
--- a/AOB.cpp
+++ b/AOB.cpp
@@ -52,7 +52,7 @@ namespace AOB {
 		return bytes;
 	}
 
-	int Scan(char* content, char* mask, DWORD min, DWORD max)
+	DWORD Scan(char* content, char* mask, DWORD min, DWORD max)
 	{
 		SYSTEM_INFO si;
 		GetSystemInfo(&si);
@@ -68,7 +68,7 @@ namespace AOB {
 			if (mi.State != MEM_COMMIT) continue;
 			if ((mi.Type == MEM_MAPPED) || (mi.Type == MEM_PRIVATE)) continue;
 			if ((mi.Protect & PAGE_NOACCESS)) continue;
-			int addr = FindPattern(lpAddr, si.dwPageSize, (BYTE*)content, mask);
+			DWORD addr = FindPattern(lpAddr, si.dwPageSize, (BYTE*)content, mask);
 			if (addr != 0)
 			{
 				return addr;

--- a/AOB.h
+++ b/AOB.h
@@ -1,7 +1,7 @@
 #pragma once
 
 namespace AOB {
-	int Scan(char* content, char* mask, DWORD min, DWORD max);
+	DWORD Scan(char* content, char* mask, DWORD min, DWORD max);
 
 	//Consider: https://github.com/CvX/hadesmem
 	DWORD FindPattern(DWORD dwAddress, DWORD dwLen, BYTE* bMask, char* szMask);


### PR DESCRIPTION
I think you meant to use DWORD there since AOB::FindPattern also returns a DWORD.
Internally most of the times "int" is the same byte size as "DWORD", but better save than sorry.